### PR TITLE
upgrade dask

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1438,31 +1438,32 @@ reference = "internal repository mirroring psycopg binary for macos"
 
 [[package]]
 name = "dask"
-version = "2022.10.2"
+version = "2025.2.0"
 description = "Parallel PyData with Task Scheduling"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 files = [
-    {file = "dask-2022.10.2-py3-none-any.whl", hash = "sha256:928003a97b890a14c8a09a01f15320d261053bda530a8bf191d84f33db4a63b8"},
-    {file = "dask-2022.10.2.tar.gz", hash = "sha256:42cb43f601709575fa46ce09e74bea83fdd464187024f56954e09d9b428ceaab"},
+    {file = "dask-2025.2.0-py3-none-any.whl", hash = "sha256:f0fdeef6ceb0a06569d456c9e704f220f7f54e80f3a6ea42ab98cea6bc642b6e"},
+    {file = "dask-2025.2.0.tar.gz", hash = "sha256:89c87125d04d28141eaccc4794164ce9098163fd22d8ad943db48f8d4c815460"},
 ]
 
 [package.dependencies]
-click = ">=7.0"
-cloudpickle = ">=1.1.1"
-fsspec = ">=0.6.0"
+click = ">=8.1"
+cloudpickle = ">=3.0.0"
+fsspec = ">=2021.09.0"
+importlib_metadata = {version = ">=4.13.0", markers = "python_version < \"3.12\""}
 packaging = ">=20.0"
-partd = ">=0.3.10"
+partd = ">=1.4.0"
 pyyaml = ">=5.3.1"
-toolz = ">=0.8.2"
+toolz = ">=0.10.0"
 
 [package.extras]
-array = ["numpy (>=1.18)"]
-complete = ["bokeh (>=2.4.2,<3)", "distributed (==2022.10.2)", "jinja2", "numpy (>=1.18)", "pandas (>=1.0)"]
-dataframe = ["numpy (>=1.18)", "pandas (>=1.0)"]
-diagnostics = ["bokeh (>=2.4.2,<3)", "jinja2"]
-distributed = ["distributed (==2022.10.2)"]
-test = ["pandas[test]", "pre-commit", "pytest", "pytest-rerunfailures", "pytest-xdist"]
+array = ["numpy (>=1.24)"]
+complete = ["dask[array,dataframe,diagnostics,distributed]", "lz4 (>=4.3.2)", "pyarrow (>=14.0.1)"]
+dataframe = ["dask[array]", "pandas (>=2.0)", "pyarrow (>=14.0.1)"]
+diagnostics = ["bokeh (>=3.1.0)", "jinja2 (>=2.10.3)"]
+distributed = ["distributed (==2025.2.0)"]
+test = ["pandas[test]", "pre-commit", "pytest", "pytest-cov", "pytest-mock", "pytest-rerunfailures", "pytest-timeout", "pytest-xdist"]
 
 [package.source]
 type = "legacy"
@@ -9162,4 +9163,4 @@ transformers = ["sentencepiece", "transformers"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10, <3.11"
-content-hash = "9d55fd388fd66340dfbef612a49d400200959460d72bfda1bd73c9bcd8a107f5"
+content-hash = "e62fc496d85c2fa18e2141fbbd74591870933cab8d2d86b6325a6ee75daef54c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,7 +175,7 @@ version = "^0.37"
 markers = "sys_platform == 'darwin' and platform_machine != 'arm64'"
 
 [[tool.poetry.dependencies.dask]]
-version = "^2022"
+version = "^2025"
 python = ">=3.8,<3.11"
 
 [[tool.poetry.dependencies.numpy]]


### PR DESCRIPTION
This PR will update Rasa Dask dep to ^2025

Dask versions <=2024.8.2 contain a vulnerability in the Dask Distributed Server where the use of pickle serialization allows attackers to craft malicious objects. These objects can be serialized on the client side and sent to the server for deserialization, leading to remote command execution and potentially granting full control over the Dask server.