### PR TITLE
downgrade to dask 2024.9.1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1438,20 +1438,20 @@ reference = "internal repository mirroring psycopg binary for macos"
 
 [[package]]
 name = "dask"
-version = "2024.12.1"
+version = "2024.9.1"
 description = "Parallel PyData with Task Scheduling"
 optional = false
 python-versions = ">=3.10"
 files = [
-    {file = "dask-2024.12.1-py3-none-any.whl", hash = "sha256:1f32acddf1a6994e3af6734756f0a92467c47050bc29f3555bb9b140420e8e19"},
-    {file = "dask-2024.12.1.tar.gz", hash = "sha256:bac809af21c2dd7eb06827bccbfc612504f3ee6435580e548af912828f823195"},
+    {file = "dask-2024.9.1-py3-none-any.whl", hash = "sha256:3757bb6c976f0436fef6bd6ad32f8983ee5ce7d8a738a1f643e208cd390ec794"},
+    {file = "dask-2024.9.1.tar.gz", hash = "sha256:06eccc6a68d2882bcd9de24548fa96e8d0da7fbfff0baed3f3c2a526b73dfbb4"},
 ]
 
 [package.dependencies]
 click = ">=8.1"
 cloudpickle = ">=3.0.0"
 fsspec = ">=2021.09.0"
-importlib_metadata = {version = ">=4.13.0", markers = "python_version < \"3.12\""}
+importlib-metadata = {version = ">=4.13.0", markers = "python_version < \"3.12\""}
 packaging = ">=20.0"
 partd = ">=1.4.0"
 pyyaml = ">=5.3.1"
@@ -1462,7 +1462,7 @@ array = ["numpy (>=1.24)"]
 complete = ["dask[array,dataframe,diagnostics,distributed]", "lz4 (>=4.3.2)", "pyarrow (>=14.0.1)"]
 dataframe = ["dask-expr (>=1.1,<1.2)", "dask[array]", "pandas (>=2.0)"]
 diagnostics = ["bokeh (>=3.1.0)", "jinja2 (>=2.10.3)"]
-distributed = ["distributed (==2024.12.1)"]
+distributed = ["distributed (==2024.9.1)"]
 test = ["pandas[test]", "pre-commit", "pytest", "pytest-cov", "pytest-rerunfailures", "pytest-timeout", "pytest-xdist"]
 
 [package.source]
@@ -9163,4 +9163,4 @@ transformers = ["sentencepiece", "transformers"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10, <3.11"
-content-hash = "1f41f51062516b39e67c63d8528f3d9232dbe4c21a21da34d495b81eee293c76"
+content-hash = "b499f2e8c0576c4f879f29f907905a33ddd4cc2c9844e90b5abf6a729a94fb14"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1438,13 +1438,13 @@ reference = "internal repository mirroring psycopg binary for macos"
 
 [[package]]
 name = "dask"
-version = "2025.2.0"
+version = "2024.12.1"
 description = "Parallel PyData with Task Scheduling"
 optional = false
 python-versions = ">=3.10"
 files = [
-    {file = "dask-2025.2.0-py3-none-any.whl", hash = "sha256:f0fdeef6ceb0a06569d456c9e704f220f7f54e80f3a6ea42ab98cea6bc642b6e"},
-    {file = "dask-2025.2.0.tar.gz", hash = "sha256:89c87125d04d28141eaccc4794164ce9098163fd22d8ad943db48f8d4c815460"},
+    {file = "dask-2024.12.1-py3-none-any.whl", hash = "sha256:1f32acddf1a6994e3af6734756f0a92467c47050bc29f3555bb9b140420e8e19"},
+    {file = "dask-2024.12.1.tar.gz", hash = "sha256:bac809af21c2dd7eb06827bccbfc612504f3ee6435580e548af912828f823195"},
 ]
 
 [package.dependencies]
@@ -1460,10 +1460,10 @@ toolz = ">=0.10.0"
 [package.extras]
 array = ["numpy (>=1.24)"]
 complete = ["dask[array,dataframe,diagnostics,distributed]", "lz4 (>=4.3.2)", "pyarrow (>=14.0.1)"]
-dataframe = ["dask[array]", "pandas (>=2.0)", "pyarrow (>=14.0.1)"]
+dataframe = ["dask-expr (>=1.1,<1.2)", "dask[array]", "pandas (>=2.0)"]
 diagnostics = ["bokeh (>=3.1.0)", "jinja2 (>=2.10.3)"]
-distributed = ["distributed (==2025.2.0)"]
-test = ["pandas[test]", "pre-commit", "pytest", "pytest-cov", "pytest-mock", "pytest-rerunfailures", "pytest-timeout", "pytest-xdist"]
+distributed = ["distributed (==2024.12.1)"]
+test = ["pandas[test]", "pre-commit", "pytest", "pytest-cov", "pytest-rerunfailures", "pytest-timeout", "pytest-xdist"]
 
 [package.source]
 type = "legacy"
@@ -9163,4 +9163,4 @@ transformers = ["sentencepiece", "transformers"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10, <3.11"
-content-hash = "e62fc496d85c2fa18e2141fbbd74591870933cab8d2d86b6325a6ee75daef54c"
+content-hash = "1f41f51062516b39e67c63d8528f3d9232dbe4c21a21da34d495b81eee293c76"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,7 +175,7 @@ version = "^0.37"
 markers = "sys_platform == 'darwin' and platform_machine != 'arm64'"
 
 [[tool.poetry.dependencies.dask]]
-version = "2024.12.1"
+version = "2024.9.1"
 python = ">=3.8,<3.11"
 
 [[tool.poetry.dependencies.numpy]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,7 +175,7 @@ version = "^0.37"
 markers = "sys_platform == 'darwin' and platform_machine != 'arm64'"
 
 [[tool.poetry.dependencies.dask]]
-version = "^2025"
+version = "2024.12.1"
 python = ">=3.8,<3.11"
 
 [[tool.poetry.dependencies.numpy]]


### PR DESCRIPTION
Turns out that dask 2025 breaks Rasa training. I am setting dask to 2024.9.1 which runs training successfully without breaking and is a higher version than the 2024.8.2 version affected by the vulnerability.