### PR TITLE
docs: CRE-5047 document CVE-2023-38545 risk acceptance for TF-bundled curl header

### DIFF
--- a/SECURITY-CVE-risk-acceptance.md
+++ b/SECURITY-CVE-risk-acceptance.md
@@ -228,6 +228,41 @@ The long-term fix is to replace Rasa entirely, which removes the TensorFlow depe
 
 ---
 
+### 7. CVE-2023-38545 — curl/libcurl Bundled Header in TensorFlow Wheel
+
+**Date accepted:** 2026-05-27  
+**Accepted by:** Engineering team (see CRE-5047)  
+**Review date:** 2027-06-01 (or when Rasa is replaced)
+
+| Field | Detail |
+|---|---|
+| CVE | CVE-2023-38545 |
+| Affected package | `curl/libcurl 7.88.0` — bundled as a **C++ header file** inside `tensorflow 2.12.1` pip wheel |
+| File path | `/usr/local/lib/python3.10/site-packages/tensorflow/include/external/curl/include/curl/curlver.h` |
+| CVSS score | 9.8 Critical |
+| CVSS vector | `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H` |
+| Fix version | curl ≥ 8.4.0 / tensorflow ≥ 2.13 |
+| Inspector finding | `arn:aws:inspector2:us-east-2:970547336042:finding/0fb104d202305025feecae2276bd2caa` |
+
+**Description:** TensorFlow 2.12.1 ships `curlver.h` (a C++ include header declaring the bundled curl version as 7.88.0) inside its pip wheel at `tensorflow/include/external/curl/`. AWS Inspector reads the version number from this header file and raises a CVSS 9.8 finding. The header is **not a compiled binary and is never loaded or executed at runtime** — it is only used if downstream code compiles against TensorFlow's bundled C++ headers, which does not happen in this service.
+
+**Why the OS-level fix does not resolve this:** Installing `libcurl4t64 ≥ 8.4.0` at the apt layer (done in PR #3336) replaces the system `libcurl` shared library but does not modify files inside the TensorFlow pip wheel. Inspector's `packageManager: GENERIC` scanner finds the version string in the header file independently of the OS package database.
+
+**Why we cannot fully remediate:** The `curlver.h` header will remain at version 7.88.0 for as long as `tensorflow 2.12.1` is installed. Upgrading TensorFlow beyond 2.12 breaks Rasa 3.x model loading (see CRE-4587).
+
+**Compensating controls:**
+
+1. **The vulnerable file is a C++ header, not a binary.** `curlver.h` contains only `#define` macros declaring version numbers. No curl network code is compiled from it at runtime; the actual HTTP/S operations performed by the service use the OS-level `libcurl4t64 ≥ 8.4.0` (patched).
+2. **The SOCKS5 heap overflow requires an active network connection through a SOCKS5 proxy.** The rasa-server pod does not make outbound connections through a SOCKS5 proxy — egress is restricted via Kubernetes NetworkPolicy to known internal endpoints only.
+3. **AWS Inspector suppression rule applied** (`arn:aws:inspector2:us-east-2:970547336042:owner/970547336042/filter/1a2777de2bdba19a`) scoped to `svc-rasa-server` in the prod account, suppressing this specific finding for this repository only.
+
+**References:**
+- Jira: [CRE-5047](https://cairehealth.atlassian.net/browse/CRE-5047)
+- NVD: https://nvd.nist.gov/vuln/detail/CVE-2023-38545
+- Code reference: `services/rasa-server/Dockerfile` (libcurl4t64 installed at OS layer via PR #3336)
+
+---
+
 ## CVE status summary
 
 | CVE | Package | CVSS | Severity | Fix available without TF upgrade? | Production? | Accepted? |
@@ -238,6 +273,7 @@ The long-term fix is to replace Rasa entirely, which removes the TensorFlow depe
 | CVE-2026-26007 | cryptography 44.0.1 | 6.5 / 8.2 | Medium/High | No | Yes | ✅ |
 | CVE-2026-34073 | cryptography 44.0.1 | 5.3 / 1.7 | Medium/Low | No | Yes | ✅ |
 | CVE-2026-21226 | azure-core 1.29.1 | 7.5 | High | No | **Dev only** | ✅ |
+| CVE-2023-38545 | curl header in tensorflow 2.12.1 pip wheel | 9.8 | Critical | No (header, not binary) | Yes | ✅ (Inspector suppressed) |
 
 ---
 


### PR DESCRIPTION
## Summary

- Documents CVE-2023-38545 in `SECURITY-CVE-risk-acceptance.md` as a TensorFlow-blocked finding
- Records the AWS Inspector suppression rule that was applied

## Root cause

AWS Inspector flags `curl/libcurl 7.88.0` as CVSS 9.8 Critical on every `svc-rasa-server` image, including ones built after the OS-level fix in caire-services PR #3336. The finding is **not** the OS libcurl — it is a C++ header file bundled inside the TensorFlow 2.12.1 pip wheel:

```
/usr/local/lib/python3.10/site-packages/tensorflow/include/external/curl/include/curl/curlver.h
```

Inspector reads `7.88.0` from the `#define` macros in this header and raises the finding with `packageManager: GENERIC`. Installing `libcurl4t64 ≥ 8.4.0` at the apt layer has no effect on files inside pip wheels.

The header is never compiled or executed at runtime. Full remediation requires TensorFlow > 2.12, which is blocked by Rasa 3.x incompatibility (CRE-4587).

## Actions taken

1. **Inspector suppression rule created** in prod account (970547336042), scoped to `svc-rasa-server`:
   `arn:aws:inspector2:us-east-2:970547336042:owner/970547336042/filter/1a2777de2bdba19a`
2. **Risk acceptance documented** in `SECURITY-CVE-risk-acceptance.md` with full explanation and compensating controls

## Test plan

- [ ] Confirm the Inspector finding `0fb104d202305025feecae2276bd2caa` moves to SUPPRESSED status within ~1 hour of the suppression rule being applied
- [ ] Confirm Vanta no longer shows CVE-2023-38545 for `svc-rasa-server` after its next sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)