### PR TITLE
CRE-5152: Tighten CVE floor constraints for aiohttp, gitpython; document cryptography blocker

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -10567,4 +10567,4 @@ transformers = ["sentencepiece", "transformers"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10, <3.11"
-content-hash = "fb74b1025c7a84e6a483c361a398cdc9d142fe37aa142617cd5334165c1de082"
+content-hash = "c12859de14e150a741ab061a6eb436a75184ebb4f156155785883f2deac6c01b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,8 +121,8 @@ sanic-jwt = "^1.8"
 sanic-routing = "^0.7"
 websockets = "^10.4"
 cloudpickle = "^3"
-aiohttp = ">=3.14.1"
-gitpython = ">=3.1.47"
+aiohttp = ">=3.14.3"        # CVE-2026-69244: fixed in 3.14.3
+gitpython = ">=3.1.57"     # Multiple CVEs (GHSA-rwj8-pgh3-r573/GHSA-3rp5-jjmw-4wv2 etc): fixed above 3.1.56
 fonttools = ">=4.60.2"
 h11 = ">=0.16.0"
 questionary = "^2.0"
@@ -159,6 +159,9 @@ dnspython = "^2.6"
 wheel = "^0.46"
 certifi = "^2025"
 cryptography = ">=45.0.0"  # CVE floor: 3 CVEs fixed above 44.0.3; ^44.0 removed to allow 45.x+
+# NOTE: GHSA-537c-gmf6-5ccf (fixed >=48.0.1) and CVE-2026-69247 (fixed >=50.0.0) cannot be patched:
+#   cryptography>=48 requires typing-extensions>=4.13.2, blocked by tensorflow==2.12.1 (<4.6.0)
+#   Vanta deferral required — see CRE-5152 and SECURITY-CVE-risk-acceptance.md
 lockfile = "^0.12"
 jax = "^0.4"
 jaxlib = "^0.4"


### PR DESCRIPTION
## Summary

Addresses Vanta high-severity CVE findings (CRE-5152) in the rasa fork.

**Changes:**
- `aiohttp`: `>=3.14.1` → `>=3.14.3` — CVE-2026-69244 (CVSS 7.5); lock was already resolving at 3.14.3, floor now matches
- `gitpython`: `>=3.1.47` → `>=3.1.57` — GHSA-rwj8-pgh3-r573, GHSA-3rp5-jjmw-4wv2, and 7 other CVEs fixed above 3.1.56; lock was already resolving at 3.1.57, floor now matches
- `cryptography`: added comment documenting why GHSA-537c-gmf6-5ccf (fix >=48.0.1) and CVE-2026-69247 (fix >=50.0.0) **cannot be patched** — `cryptography >=48` requires `typing-extensions >=4.13.2`, but `tensorflow==2.12.1` hard-pins `typing-extensions <4.6.0`; Vanta deferral required for CRE-5152

**No actual package version changes** — the lock already resolved all three packages at safe versions. This PR tightens the floor constraints so future `poetry lock` regenerations cannot regress to vulnerable versions.

**Packages already at safe versions (no change needed):**
- `pillow` → 12.3.0 (requires >=12.3.0) ✅
- `pyasn1` → 0.6.4 (requires >=0.6.4) ✅
- `nltk`, `soupsieve` — not present as direct or transitive deps in this fork ✅

## Cryptography blocker

```
cryptography>=48 requires typing-extensions>=4.13.2
tensorflow==2.12.1 pins typing-extensions <4.6.0
→ Resolution fails; deferral documented in pyproject.toml and CRE-5152
```

## Test plan

- [ ] CI passes (no functional changes, only floor bumps)
- [ ] Verify `poetry lock` still resolves cleanly after merge

Jira: [CRE-5152](https://cairehealth.atlassian.net/browse/CRE-5152)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CRE-5152]: https://cairehealth.atlassian.net/browse/CRE-5152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ