### PR TITLE
fix(cve): bump gitpython floor to >=3.1.58 (new CVE for <=3.1.57)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2633,14 +2633,14 @@ reference = "internal repository mirroring psycopg binary for macos"
 
 [[package]]
 name = "gitpython"
-version = "3.1.57"
+version = "3.1.58"
 description = "GitPython is a Python library used to interact with Git repositories"
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
 files = [
-    {file = "gitpython-3.1.57-py3-none-any.whl", hash = "sha256:4ccf7d73c10f5c9e76043fbb2675ac5a1b3ff5b41e648f56bcbed5f63792ecaf"},
-    {file = "gitpython-3.1.57.tar.gz", hash = "sha256:c493ec57c0ef6b19743798b6a5af859c71814b524e7e6f97baa2f8e658961488"},
+    {file = "gitpython-3.1.58-py3-none-any.whl", hash = "sha256:d331e722577f0fd7fc1f857419b3ecc07af66282b933d2a4d95f84a042fdd50f"},
+    {file = "gitpython-3.1.58.tar.gz", hash = "sha256:621416df10ef3fd0e19fabf9172ddeed0fa704d353d04f194eec56a625a95b22"},
 ]
 
 [package.dependencies]
@@ -10567,4 +10567,4 @@ transformers = ["sentencepiece", "transformers"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10, <3.11"
-content-hash = "c12859de14e150a741ab061a6eb436a75184ebb4f156155785883f2deac6c01b"
+content-hash = "0adc9da1b9f021d3bc7cccb3bcbcd629216d8226501cb9b5a3eee4637f2e259b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ sanic-routing = "^0.7"
 websockets = "^10.4"
 cloudpickle = "^3"
 aiohttp = ">=3.14.3"        # CVE-2026-69244: fixed in 3.14.3
-gitpython = ">=3.1.57"     # Multiple CVEs (GHSA-rwj8-pgh3-r573/GHSA-3rp5-jjmw-4wv2 etc): fixed above 3.1.56
+gitpython = ">=3.1.58"     # Multiple CVEs + new finding for <=3.1.57: fixed above 3.1.57
 fonttools = ">=4.60.2"
 h11 = ">=0.16.0"
 questionary = "^2.0"


### PR DESCRIPTION
## Summary

- Bumps `gitpython` floor from `>=3.1.57` to `>=3.1.58` to address new Vanta finding for `pip-GitPython <= 3.1.57`
- Regenerated `poetry.lock` — gitpython now resolves to `3.1.58`

**CVE addressed:** New high-severity finding for `gitpython <= 3.1.57` (appeared in Vanta Aug 2026 scan)

## Test plan
- [ ] CI passes
- [ ] `poetry.lock` shows `gitpython = "3.1.58"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)